### PR TITLE
liblcvm: add frame drop consecutive count

### DIFF
--- a/include/liblcvm.h
+++ b/include/liblcvm.h
@@ -30,6 +30,8 @@
 // @param[in] percentile_list: Percentile list.
 // @param[out] frame_drop_length_percentile_list: Frame drop length percentile
 // list.
+// @param[in] consecutive_list: Consecutive list.
+// @param[out] frame_drop_length_consecutive: Frame drop length consecutive.
 // @param[in] debug: Debug level.
 int get_frame_drop_info(const char *infile, int *num_video_frames,
                         float *frame_rate_fps_median,
@@ -39,6 +41,8 @@ int get_frame_drop_info(const char *infile, int *num_video_frames,
                         float *normalized_frame_drop_average_length,
                         const std::vector<float> percentile_list,
                         std::vector<float> &frame_drop_length_percentile_list,
+                        const std::vector<int> consecutive_list,
+                        std::vector<long int> &frame_drop_length_consecutive,
                         int debug);
 
 // @brief Calculates the video freeze info.

--- a/src/liblcvm.cc
+++ b/src/liblcvm.cc
@@ -178,6 +178,8 @@ int get_frame_drop_info(const char *infile, int *num_video_frames,
                         float *normalized_frame_drop_average_length,
                         const std::vector<float> percentile_list,
                         std::vector<float> &frame_drop_length_percentile_list,
+                        std::vector<int> consecutive_list,
+                        std::vector<long int> &frame_drop_length_consecutive,
                         int debug) {
   // 0. get the list of inter-frame timestamp distances.
   float duration_video_sec;
@@ -290,6 +292,23 @@ int get_frame_drop_info(const char *infile, int *num_video_frames,
       frame_drop_length_percentile_list.push_back(0.0);
     }
   }
+
+  // 9. calculate consecutive list
+  frame_drop_length_consecutive.clear();
+  for (int element : consecutive_list) {
+      frame_drop_length_consecutive.push_back(0);
+  }
+  if (drop_length_sec_list.size() > 0) {
+      for (const auto &drop_length_sec : drop_length_sec_list) {
+           float drop_length =  drop_length_sec / delta_timestamp_sec_median;
+           for (int i = 0; i < consecutive_list.size(); i++) {
+               if (drop_length >= consecutive_list[i]) {
+                   frame_drop_length_consecutive[i]++;
+               }
+           }
+      }
+  } 
+  
   return 0;
 }
 

--- a/tools/lcvm.cc
+++ b/tools/lcvm.cc
@@ -56,7 +56,8 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
           "video_freeze_ratio,duration_video_sec,duration_audio_sec,"
           "frame_drop_count,frame_drop_ratio,"
           "normalized_frame_drop_average_length,"
-          "frame_drop_length_percentile_50,frame_drop_length_percentile_90\n");
+          "frame_drop_length_percentile_50,frame_drop_length_percentile_90,"
+          "frame_drop_length_consecutive_2,frame_drop_length_consecutive_5\n");
 
   // 2. write CSV rows
   std::vector<std::vector<float>> delta_timestamp_sec_list_list;
@@ -83,11 +84,14 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
     std::vector<float> percentile_list = {50, 90};
     std::vector<float> frame_drop_length_percentile_list;
     float normalized_frame_drop_average_length;
+    std::vector<int> consecutive_list = {2, 5};
+    std::vector<long int> frame_drop_length_consecutive;
     ret = get_frame_drop_info(
         infile.c_str(), &num_video_frames, &frame_rate_fps_median,
         &frame_rate_fps_average, &frame_rate_fps_stddev, &frame_drop_count,
         &frame_drop_ratio, &normalized_frame_drop_average_length,
-        percentile_list, frame_drop_length_percentile_list, debug);
+        percentile_list, frame_drop_length_percentile_list, consecutive_list,
+        frame_drop_length_consecutive,debug);
     if (ret < 0) {
       fprintf(stderr, "error: get_frame_drop_info() in %s\n", infile.c_str());
       return -1;
@@ -108,6 +112,8 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
     fprintf(outfp, ",%f", normalized_frame_drop_average_length);
     fprintf(outfp, ",%f", frame_drop_length_percentile_list[0]);
     fprintf(outfp, ",%f", frame_drop_length_percentile_list[1]);
+    fprintf(outfp, ",%ld", frame_drop_length_consecutive[0]);
+    fprintf(outfp, ",%ld", frame_drop_length_consecutive[1]);
     fprintf(outfp, "\n");
 
     // 2.4. capture outfile timestamps


### PR DESCRIPTION
for an input {2,5} following is the result there are 371 consecutive frame drops which are more than 2 and 13 times are more than 5.

% csvcut -c num_video_frames,frame_rate_fps_median,frame_drop_ratio,frame_drop_length_consecutive_2,frame_drop_length_consecutive_5 out.csv|csvlook
    | num_video_frames | frame_rate_fps_median | frame_drop_ratio | frame_drop_length_consecutive_2 | frame_drop_length_consecutive_5 |
    | ---------------- | --------------------- | ---------------- | ------------------------------- | ------------------------------- |
    |            7,583 |               30.000… |           0.152… |                             371 |                              13 |