### PR TITLE
liblcvm: fix for cmake failure in Apple ARM silicon chipsets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(lcvm)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "" FORCE)
+
 # Set compiler flags
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra -Wno-unused-parameter -Wshadow -Werror")
 


### PR DESCRIPTION
fix for ``` ld: warning: ignoring file '~/liblcvm/lib/isobmff/Build/Debug/Products/x86_64/libISOBMFF.a[2](ISOBMFF.o)': found architecture 'x86_64', required architecture 'arm64'
Undefined symbols for architecture arm64:```