### PR TITLE
update compute logic of audio to video ratio

### DIFF
--- a/src/liblcvm.cc
+++ b/src/liblcvm.cc
@@ -27,7 +27,7 @@
 
 #include "config.h"
 
-#define MAX_AUDIO_VIDEO_RATIO 0.05
+#define MAX_AUDIO_VIDEO_RATIO 1.05
 
 int get_liblcvm_version(std::string &version) {
   version = PROJECT_VER;
@@ -829,8 +829,7 @@ int get_video_freeze_info(const struct IsobmffFileInformation &info,
   }
 
   // 2. calculate audio to video ratio
-  *audio_video_ratio =
-      (*duration_audio_sec - *duration_video_sec) / *duration_audio_sec;
+  *audio_video_ratio = *duration_audio_sec / *duration_video_sec;
   *video_freeze = *audio_video_ratio > MAX_AUDIO_VIDEO_RATIO;
   return 0;
 }


### PR DESCRIPTION
**Summary**
The existing computation logic for the audio-to-video ratio does not align with our intuitive understanding based on the metric's name. To address this, this diff updates the computation logic to accurately calculate the ratio by dividing the duration of the audio by the duration of the video.
This division is safeguarded against potential divide-by-zero issues, as the preceding if statement addresses the edge case where the video duration is less than 2 seconds.

**Test Plan**
Build and run lcvm
`./lcvm ~/Downloads/video.mp4 -o full.csv`
I am able to read a valid output with metrics about the video. https://pxl.cl/69KTJ

_Note: 
I comment out `add_subdirectory(test)` in lib/h264nal/CMakeLists.txt and lib/h265nal/CmakeLists.txt to unblock myself from build failure. 
Leelakrishna will continue investigating the root cause of the build failure.
Since the comment out piece are about tests, it should be low risk to proceed with the code change._