### PR TITLE
update the condition to compute video_freeze and audio_to_video_ratio metric

### DIFF
--- a/src/liblcvm.cc
+++ b/src/liblcvm.cc
@@ -495,8 +495,8 @@ int TimingInformation::derive_timing_info(
 
   // 5. audio/video ratio and video freeze info
   if ((ptr->timing.duration_video_sec != -1.0) &&
-      (ptr->timing.duration_audio_sec == -1.0) &&
-      (ptr->timing.duration_video_sec < 2.0)) {
+      (ptr->timing.duration_audio_sec != -1.0) &&
+      (ptr->timing.duration_video_sec >= 2.0)) {
     ptr->timing.audio_video_ratio =
         ptr->timing.duration_audio_sec / ptr->timing.duration_video_sec;
     ptr->timing.video_freeze =

--- a/tools/lcvm.cc
+++ b/tools/lcvm.cc
@@ -66,7 +66,7 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
           "matrix_coeffs,"
           "num_video_frames,frame_rate_fps_median,"
           "frame_rate_fps_average,frame_rate_fps_stddev,video_freeze,"
-          "video_freeze_ratio,duration_video_sec,duration_audio_sec,"
+          "audio_video_ratio,duration_video_sec,duration_audio_sec,"
           "timescale_video_hz,timescale_audio_hz,"
           "pts_duration_sec_average,pts_duration_sec_median,"
           "pts_duration_sec_stddev,pts_duration_sec_mad,"


### PR DESCRIPTION
There are recent refactoring that unexpectedly change the 'if condition' that compute the video_freeze and audio_to_video_ratio metric.
This diff revert the unexpected change to compute these metrics when duration of audio is available and duration of video is available and 'longer or equal to 2s'.

Code before refactoring
https://www.internalfb.com/code/fbsource/[5de30b0bda0b32ff0aa46c3904e3ac69cc1dc0a8]/third-party/liblcvm/liblcvm_0_0/src/liblcvm.cc?lines=385-407

Before update:
<img width="416" alt="Screenshot 2025-01-08 at 4 10 16 PM" src="https://github.com/user-attachments/assets/6eb949ac-213d-4c98-a725-90823acd9c8d" />
After update:
<img width="434" alt="Screenshot 2025-01-08 at 4 01 42 PM" src="https://github.com/user-attachments/assets/ea5639c2-a3db-4077-871a-061addd2b9f0" />

The diff also update the lcvm tool to correctly name the metrics as "audio_video_ratio".