### PR TITLE
Added new output param - reverse average fps

### DIFF
--- a/include/liblcvm.h
+++ b/include/liblcvm.h
@@ -70,6 +70,9 @@ class TimingInformation {
   float frame_rate_fps_median;
   // frame_rate_fps_average: Frame rate (average, fps).
   float frame_rate_fps_average;
+  // frame_rate_fps_reverse_average: Average frame rate calculated
+  // as the reverse of average PTS duration (sec)
+  float frame_rate_fps_reverse_average;
   // frame_rate_fps_stddev: Frame rate (stddev).
   float frame_rate_fps_stddev;
   // frame_drop_length_sec_list: Vector of lengths between frame drops.
@@ -106,6 +109,7 @@ class TimingInformation {
   DECL_GETTER(frame_rate_fps_list, std::vector<float>)
   DECL_GETTER(frame_rate_fps_median, float)
   DECL_GETTER(frame_rate_fps_average, float)
+  DECL_GETTER(frame_rate_fps_reverse_average, float)
   DECL_GETTER(frame_rate_fps_stddev, float)
   DECL_GETTER(frame_drop_length_sec_list, std::vector<float>)
   DECL_GETTER(frame_drop_count, int)

--- a/src/liblcvm.cc
+++ b/src/liblcvm.cc
@@ -519,7 +519,19 @@ int TimingInformation::derive_timing_info(
   // 6.3. average
   ptr->timing.frame_rate_fps_average =
       calculate_average(ptr->timing.frame_rate_fps_list);
-  // 6.4. stddev
+  // 6.4. reverse average
+  // Considering the sample_duration of different frames inside boxes
+  // as a series X: {x1, x2, ..., xn}, for calculating average FPS from this,
+  // consider the reciprocal series Y = 1/X = {1/x1, 1/x2, ..., 1/xn}
+  // The average of X is $\hat{X}$.
+  // The average of Y is $\hat{Y}$.
+  // A single, very small number $xi$ can cause this average ($\hat{Y}$) to be
+  // extreme, leading to extreme values in frame_rate_fps_average calculation.
+  // In contrast, the reverse of the average of X ($1/\hat{X}$) should not
+  // have this biased to extreme value.
+  ptr->timing.frame_rate_fps_reverse_average =
+      1.0/ptr->timing.pts_duration_sec_average;
+  // 6.5. stddev
   ptr->timing.frame_rate_fps_stddev =
       calculate_standard_deviation(ptr->timing.frame_rate_fps_list);
 

--- a/tools/lcvm.cc
+++ b/tools/lcvm.cc
@@ -64,8 +64,8 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
           "colour_primaries,"
           "transfer_characteristics,"
           "matrix_coeffs,"
-          "num_video_frames,frame_rate_fps_median,"
-          "frame_rate_fps_average,frame_rate_fps_stddev,video_freeze,"
+          "num_video_frames,frame_rate_fps_median,frame_rate_fps_average,"
+          "frame_rate_fps_reverse_average,frame_rate_fps_stddev,video_freeze,"
           "audio_video_ratio,duration_video_sec,duration_audio_sec,"
           "timescale_video_hz,timescale_audio_hz,"
           "pts_duration_sec_average,pts_duration_sec_median,"
@@ -130,6 +130,8 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
     float frame_rate_fps_median = ptr->get_timing().get_frame_rate_fps_median();
     float frame_rate_fps_average =
         ptr->get_timing().get_frame_rate_fps_average();
+    float frame_rate_fps_reverse_average =
+        ptr->get_timing().get_frame_rate_fps_reverse_average();
     float frame_rate_fps_stddev = ptr->get_timing().get_frame_rate_fps_stddev();
     int frame_drop_count = ptr->get_timing().get_frame_drop_count();
     float frame_drop_ratio = ptr->get_timing().get_frame_drop_ratio();
@@ -172,6 +174,7 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
     fprintf(outfp, ",%i", num_video_frames);
     fprintf(outfp, ",%f", frame_rate_fps_median);
     fprintf(outfp, ",%f", frame_rate_fps_average);
+    fprintf(outfp, ",%f", frame_rate_fps_reverse_average);
     fprintf(outfp, ",%f", frame_rate_fps_stddev);
     fprintf(outfp, ",%i", video_freeze ? 1 : 0);
     fprintf(outfp, ",%f", audio_video_ratio);


### PR DESCRIPTION
Considering the sample_duration of different frames inside boxes as a series X: {x1, x2, ..., xn}, for calculating average FPS from this, consider the reciprocal series Y = 1/X = {1/x1, 1/x2, ..., 1/xn} The average of X is $\hat{X}$.
The average of Y is $\hat{Y}$.
A single, very small number $xi$ can cause this average ($\hat{Y}$) to be extreme, leading to extreme values in frame_rate_fps_average calculation. In contrast, the reverse of the average of X ($1/\hat{X}$) should not have this biased to extreme value.

So added another param frame_rate_fps_reverse_average