### PR TITLE
liblcvm: Add audio information from MP4A box

### DIFF
--- a/include/liblcvm.h
+++ b/include/liblcvm.h
@@ -143,6 +143,28 @@ class TimingInformation {
   friend class IsobmffFileInformation;
 };
 
+class AudioInformation {
+  private:
+  // audio_type: Audio type ("mp4a" or "mp4s").
+  std::string audio_type;
+  // audio_object_type: Audio object type (from mp4a/mp4s).
+  int channel_count;
+  // audio_sample_rate: Audio sample rate (Hz).
+  int sample_rate;
+  // audio_sample_size:
+  int sample_size;
+  public:
+  DECL_GETTER(audio_type, std::string)
+  DECL_GETTER(channel_count, int)
+  DECL_GETTER(sample_rate, int)
+  DECL_GETTER(sample_size, int)
+
+  int parse_mp4a(std::shared_ptr<ISOBMFF::ContainerBox> stbl,
+                              std::shared_ptr<IsobmffFileInformation> ptr,
+                              int debug);
+  friend class IsobmffFileInformation;
+};
+
 class FrameInformation {
  private:
   // filesize: Video file size (bytes).
@@ -220,11 +242,13 @@ class IsobmffFileInformation {
   std::string filename;
   TimingInformation timing;
   FrameInformation frame;
+  AudioInformation audio;
 
  public:
   DECL_GETTER(filename, std::string)
   DECL_GETTER(timing, TimingInformation)
   DECL_GETTER(frame, FrameInformation)
+  DECL_GETTER(audio, AudioInformation)
 
   // @brief Gets the library version.
   //
@@ -246,6 +270,7 @@ class IsobmffFileInformation {
 
   friend class TimingInformation;
   friend class FrameInformation;
+  friend class AudioInformation;
 };
 
 // DEPRECATED API (do not use).

--- a/tools/lcvm.cc
+++ b/tools/lcvm.cc
@@ -74,7 +74,8 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
           "normalized_frame_drop_average_length,"
           "frame_drop_length_percentile_50,frame_drop_length_percentile_90,"
           "frame_drop_length_consecutive_2,frame_drop_length_consecutive_5,"
-          "num_video_keyframes,key_frame_ratio\n");
+          "num_video_keyframes,key_frame_ratio,"
+          "audio_type,channel_count,sample_rate,sample_size\n");
 
   // 2. write CSV rows
   std::map<std::string, std::vector<uint32_t>> frame_num_orig_list_dict;
@@ -152,6 +153,12 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
     int num_video_keyframes = ptr->get_timing().get_num_video_keyframes();
     float key_frame_ratio = ptr->get_timing().get_key_frame_ratio();
 
+    //2.3.1 get audio structure info
+    std::string audio_type = ptr->get_audio().get_audio_type();
+    int channel_count = ptr->get_audio().get_channel_count();
+    int sample_rate = ptr->get_audio().get_sample_rate();
+    int sample_size = ptr->get_audio().get_sample_size();
+
     // 2.4. dump all output
     fprintf(outfp, "%s", infile.c_str());
     fprintf(outfp, ",%i", filesize);
@@ -195,6 +202,10 @@ int parse_files(std::vector<std::string> &infile_list, char *outfile,
     fprintf(outfp, ",%ld", frame_drop_length_consecutive[1]);
     fprintf(outfp, ",%i", num_video_keyframes);
     fprintf(outfp, ",%f", key_frame_ratio);
+    fprintf(outfp, ",%s", audio_type.c_str());
+    fprintf(outfp, ",%i", channel_count);
+    fprintf(outfp, ",%i", sample_rate);
+    fprintf(outfp, ",%i", sample_size);
     fprintf(outfp, "\n");
 
     // 2.4. capture outfile timestamps


### PR DESCRIPTION
1.Parse MP4A box to extract audio metadata (channel count, sample size, sample rate).
2.Modify src/liblcvm.cc to store the extracted audio information.
3. Append audio metadata to the output CSV file.
