### PR TITLE
liblcvm: fix main test target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ target_include_directories(liblcvm PRIVATE ${CMAKE_BINARY_DIR})
 
 # 4.1. add test target
 add_custom_target(test
-  COMMAND ${CMAKE_BINARY_DIR}/lcvm ${CMAKE_BINARY_DIR}/*MOV -o /tmp/full.csv
+  COMMAND ${CMAKE_BINARY_DIR}/lcvm ${CMAKE_SOURCE_DIR}/lib/isobmff/media/*MOV -o /tmp/full.csv
 )
 
 # 4.2. add lint target


### PR DESCRIPTION
Tested: MacOS

Before:
```
$ git clone
$ cd liblcvm/
$ mkdir build
$ cd build/
$ cmake ..
$ make -j
$ ./lcvm --help
where options are:
  -d:   Increase debug verbosity [0]
  -q:   Zero debug verbosity
  --runs <nruns>:   Run the analysis multiple times [1]
  -o outfile:   Select outfile
  --outfile-timestamps outfile_timestamps:    Select outfile to dump timestamps
  --sort-pts:   Sort outfile timestamps by PTS
  --no-sort-pts:    Do not outfile timestamps by PTS
  -h:   Help
$ make test
error: Invalid file stream
error: IsobmffFileInformation::parse() in /tmp/liblcvm/build/*MOV
Built target test
```

After:
```
$ git clone
$ cd liblcvm/
$ mkdir build
$ cd build/
$ cmake ..
$ make -j
$ ./lcvm --help
where options are:
  -d:   Increase debug verbosity [0]
  -q:   Zero debug verbosity
--runs <nruns>:   Run the analysis multiple times [1]
-o outfile:   Select outfile
--outfile-timestamps outfile_timestamps:    Select outfile to dump timestamps
--sort-pts:   Sort outfile timestamps by PTS
--no-sort-pts:    Do not outfile timestamps by PTS
-h:   Help
$ make test
-- Using default Apple Clang on macOS.
-- src: normal footprint selected
-- src: normal footprint selected
-- test: normal footprint selected
-- src: normal footprint selected
-- src: normal footprint selected
-- test: normal footprint selected
-- Configuring Liblcvm library
-- Configuring done (0.2s)
-- Generating done (1.4s)
Built target test
```